### PR TITLE
プロフィールページを中心とした修正

### DIFF
--- a/src/app/articlecreate/page.tsx
+++ b/src/app/articlecreate/page.tsx
@@ -1,3 +1,4 @@
+//src/app/articlecreate/page.tsx
 "use client";
 
 import { useState, useEffect } from "react";

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,38 +1,129 @@
-//app/profile/page.tsx
+// src/app/profile/page.tsx
 "use client";
 
-import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import LogoutButton from "../../components/modules/auth/LogoutButton";
-import { Session } from "@supabase/auth-helpers-nextjs";
+import { useState, useEffect } from "react";
+import BlogCard from "@/components/modules/blog-card";
+import { Blog } from "@/types/blog";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from "@/components/ui/pagination";
 
-const ProfilePage = () => {
-  const supabase = createClientComponentClient();
-  const [session, setSession] = useState<Session | null>(null);
+// 本番API連携が可能になるまでの仮データ（9件分）
+// 本番では getBlogs() 関数の中で API or Supabase から取得する想定
+const DUMMY_BLOGS: Blog[] = Array.from({ length: 9 }).map((_, i) => ({
+  id: `${i + 1}`,
+  title: `Post Title`,
+  content: "ダミーの本文です",
+  image_path: "/images/placeholder.jpg", // public/images/placeholder.jpg を参照
+  created_at: new Date().toISOString(),
+  user_id: "dummy-user-id",
+  users: {
+    id: "dummy-user-id",
+    name: "Author",
+    image_path: "/images/dummy-user.png", // public/images/dummy-user.png を参照
+  },
+  categories: {
+    id: 1,
+    name: "Category",
+  },
+  category_id: 1,
+}));
 
+const ITEMS_PER_PAGE = 6;
+
+export default function ProfilePage() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [blogs, setBlogs] = useState<Blog[]>([]); // ← 本番ではAPI取得データをここに格納
+
+  // 🚧 本番API実装時はここを入れ替えるだけでOK！
+  // 例: Supabase または fetch("/api/articles") を使用する想定
   useEffect(() => {
-    const fetchSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      setSession(session);
-    };
+    const getBlogs = async () => {
+      // 本番では以下のように書き換えてください
+      // const res = await fetch("/api/articles");
+      // const data = await res.json();
+      // setBlogs(data);
 
-    fetchSession();
-  }, [supabase]);
+      setBlogs(DUMMY_BLOGS); // ← 仮データ使用中
+    };
+    getBlogs();
+  }, []);
+
+  const totalPages = Math.ceil(blogs.length / ITEMS_PER_PAGE);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  // ページごとの表示データを抽出
+  const paginatedBlogs = blogs.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
 
   return (
-    <div className="max-w-3xl mx-auto mt-12 p-6 bg-[var(--color-card)] shadow-md rounded-lg">
-      {session ? (
-        <div className="flex flex-col items-center">
-          <h2 className="text-2xl font-bold text-[var(--color-foreground)]">{session.user.email}</h2>
-          <LogoutButton />
-        </div>
-      ) : (
-        <p className="text-center text-[var(--color-muted-foreground)]">ログインしてください</p>
-      )}
+    <div className="max-w-6xl mx-auto mt-12 px-4">
+      <h2 className="text-3xl font-bold text-center mb-10 text-[var(--color-foreground)]">
+        Your Post
+      </h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+        {paginatedBlogs.map((blog) => (
+          <BlogCard
+            key={blog.id}
+            post={{
+              id: blog.id,
+              title: blog.title,
+              category: blog.categories.name,
+              author: blog.users.name,
+              createdAt: "a min ago", // ⏱ 本番では相対時刻に変換可
+              image: blog.image_path,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Pagination コンポーネント：ページ送り */}
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              onClick={() => handlePageChange(Math.max(1, currentPage - 1))}
+              href="#"
+              className="gap-1 px-2.5 sm:pl-2.5"
+            >
+              ← Previous Page
+            </PaginationPrevious>
+          </PaginationItem>
+          {Array.from({ length: totalPages }).map((_, i) => (
+            <PaginationItem key={i}>
+              <PaginationLink
+                href="#"
+                isActive={currentPage === i + 1}
+                onClick={() => handlePageChange(i + 1)}
+              >
+                {i + 1}
+              </PaginationLink>
+            </PaginationItem>
+          ))}
+          <PaginationItem>
+            <PaginationNext
+              onClick={() =>
+                handlePageChange(Math.min(totalPages, currentPage + 1))
+              }
+              href="#"
+              className="gap-1 px-2.5 sm:pr-2.5"
+            >
+              Next Page →
+            </PaginationNext>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
     </div>
   );
-};
-
-export default ProfilePage;
-
-   
+}

--- a/src/components/modules/blog-card.tsx
+++ b/src/components/modules/blog-card.tsx
@@ -1,26 +1,10 @@
-// components/modules/blog-card.tsx
+// src/components/modules/blog-card.tsx
 import Link from "next/link";
-
-interface Post {
-  id: string;
-  title: string;
-  category: string;
-  author: string;
-  createdAt: string;
-  image: string;
-}
-
-interface BlogCardProps {
-  post: Post;
-  customLink?: string; // リンク先を上書きしたい場合に使用
-}
+import { Post, BlogCardProps } from "@/types/blog-card";
 
 export default function BlogCard({ post, customLink }: BlogCardProps) {
-  if (!post?.id) {
-    return null;
-  }
+  if (!post?.id) return null;
 
-  // デフォルトリンクを `/articledetail/[id]` に変更
   const href = customLink ?? `/articledetail/${post.id}`;
 
   return (
@@ -35,14 +19,22 @@ export default function BlogCard({ post, customLink }: BlogCardProps) {
           className="w-full h-full object-cover"
         />
       </div>
+
       <div className="p-4">
-        <h3 className="font-bold text-lg text-[var(--color-foreground)]">
-          {post.title}
-        </h3>
-        <p className="text-sm text-[var(--color-muted)]">{post.category}</p>
-        <div className="text-xs text-[var(--color-muted)] flex justify-between mt-2">
-          <span>{post.author}</span>
-          <span>{post.createdAt}</span>
+        {/* タイトル + カテゴリ を同一行 */}
+        <div className="flex justify-between items-center mb-2">
+          <h3 className="font-bold text-lg text-[var(--color-foreground)]">
+            {post.title}
+          </h3>
+          <p className="text-sm text-[var(--color-muted)]">{post.category}</p>
+        </div>
+
+        {/* 著者 + 日時 横並び */}
+        <div className="flex justify-between text-xs text-[var(--color-muted)]">
+          <div className="flex gap-2">
+            <span>{post.author}</span>
+            <span>{post.createdAt}</span>
+          </div>
         </div>
       </div>
     </Link>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,3 +1,4 @@
+//src/components/ui/pagination.tsx
 import * as React from "react"
 import {
   ChevronLeftIcon,

--- a/src/types/blog-card.ts
+++ b/src/types/blog-card.ts
@@ -1,0 +1,15 @@
+// src/types/blog-card.ts
+export type Post = {
+    id: string;
+    title: string;
+    category: string;
+    author: string;
+    createdAt: string;
+    image: string;
+  };
+  
+  export type BlogCardProps = {
+    post: Post;
+    customLink?: string;
+  };
+  

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,20 @@
+//src/types/blog.ts
+export type Blog = {
+    id: string;
+    title: string;
+    content: string;
+    image_path: string;
+    created_at: string;
+    user_id: string;
+    category_id: number;
+    users: {
+      id: string;
+      name: string;
+      image_path: string;
+    };
+    categories: {
+      id: number;
+      name: string;
+    };
+  };
+  


### PR DESCRIPTION
TO 伊田さん　藤野さん
CC：バックエンド担当の皆様
## 概要
プロフィールページ（/profile）のデザイン修正と、確認しやすいようダミーの投稿データを使ってカード一覧を表示できるようにしました。

## 主な変更点
- `src/app/profile/page.tsx`
  - ダミー投稿データを定義（Blog型で9件）
  - ページネーション導入（1ページ6件表示）
  - 将来的にAPI/Supabaseと連携できるよう、`useEffect`内で`getBlogs()`関数を分離
  - `createdAt`は今は `"a min ago"` で仮置き

- `src/components/modules/blog-card.tsx`
  - ワイヤーフレームに合わせ、カテゴリを右上・タイトルは左揃えで表示
  - 著者名と投稿日時を横並び表示に変更（Author a min ago）

- `src/types/blog.ts＆blog-card.ts`
  - 方定義ファイル作成

## その他の補足・変更（今回の修正と直接関係しないが併せて整理）
- フォルダ構造の一部で先頭に `//src/` を追記する形にコメント整備

レビュー・マージをお願いいたします！
