### PR TITLE
package.jsonのdependenciesに @radix-ui/react-select": "^2.1.6"`を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",
+    "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/ssr": "^0.5.2",


### PR DESCRIPTION
@yyi2502 (cc: @kujira-challenge )
記事編集ページを開いたときに、 @radix-ui/react-selectがありませんというエラーがでる問題の修正です。
`package.json`の`dependencies`に `@radix-ui/react-select": "^2.1.6"`の1行を追加しました。
ご確認いただければと思います。