### PR TITLE
記事編集画面に記事の編集、削除機能を追加

### DIFF
--- a/src/app/ArticleEdit/[id]/page.tsx
+++ b/src/app/ArticleEdit/[id]/page.tsx
@@ -107,7 +107,7 @@ export default function EditBlogPage() {
           content,
           category_id: categoryId,
           // image_path: uploadedImagePath, // 画像を変更してなければ元のをそのまま使う
-          image_path: null, // 更新確認のため一旦nullを設定
+          image_path: null, // 更新確認のため一旦nullを設定する
         }),
       });
 

--- a/src/app/ArticleEdit/[id]/page.tsx
+++ b/src/app/ArticleEdit/[id]/page.tsx
@@ -1,78 +1,169 @@
 // src/app/articleedit/[id]/page.tsx
 
-"use client";
+'use client';
 
-import { useState } from "react";
-import { useParams } from "next/navigation";
-import Input from "@/components/ui/custom/input";
-import { CustomTextarea } from "@/components/ui/custom/CustomTextarea";
-import { CreateButton } from "@/components/ui/custom/CreateButton";
-import { CategorySelect } from "@/components/ui/custom/CategorySelect";
-import { Arrow } from "@/components/ui/custom/Arrow"; // Arrowを使用
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Input from '@/components/ui/custom/input';
+import { CustomTextarea } from '@/components/ui/custom/CustomTextarea';
+import { CreateButton } from '@/components/ui/custom/CreateButton';
+import { CategorySelect } from '@/components/ui/custom/CategorySelect';
+import { Arrow } from '@/components/ui/custom/Arrow'; // Arrowを使用
+import { Blog } from '@/types/blog';
 
-// ダミーデータ（仮のデフォルト記事）
-const dummyArticles = {
-  "101": {
-    title: "ユーザ記事1",
-    category: "Programming",
-    content: "これはユーザ記事1の本文です。",
-    imageUrl: "/images/placeholder.jpg",
-  },
-  "102": {
-    title: "ユーザ記事2",
-    category: "Design",
-    content: "これはユーザ記事2の本文です。",
-    imageUrl: "/images/placeholder.jpg",
-  },
+type Category = {
+  id: number;
+  name: string;
 };
 
 export default function EditBlogPage() {
   const { id } = useParams();
-  const article = dummyArticles[id as keyof typeof dummyArticles] || {
-    title: "",
-    category: "",
-    content: "",
-    imageUrl: "/images/placeholder.jpg",
-  };
 
-  const [title, setTitle] = useState(article.title);
-  const [category, setCategory] = useState(article.category);
-  const [content, setContent] = useState(article.content);
-  const [previewSrc, setPreviewSrc] = useState<string | null>(article.imageUrl);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [imagePath, setImagePath] = useState<string | null>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [categoryList, setCategoryList] = useState<Category[]>([]);
+  const [categoryId, setCategoryId] = useState<number | null>(null);
 
-  const handleUpdate = () => {
-    console.log("更新データ:", { title, category, content, previewSrc });
-    alert("記事が更新されました！（ダミー）");
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await fetch(`/api/categories`);
+        const result = await response.json();
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(errorData.error || '記事の作成に失敗しました');
+        }
+
+        const data: Category[] = result.data;
+        setCategoryList(data);
+      } catch (error) {
+        console.error('Category fetch error:', error);
+        throw error;
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  useEffect(() => {
+    const fetchBlog = async () => {
+      try {
+        const response = await fetch(`/api/articles/${id}`);
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(errorData.error || '記事の取得に失敗しました');
+        }
+
+        const data: Blog = await response.json();
+
+        setTitle(data.title);
+        setContent(data.content);
+        setImagePath(data.image_path);
+        setCategoryId(data.category?.id ?? null);
+      } catch (error) {
+        console.error('Blog fetch error:', error);
+        throw error;
+      }
+    };
+    if (id) fetchBlog();
+  }, [id]);
+
+  const handleUpdate = async () => {
+    if (!id) return;
+
+    try {
+      let uploadedImagePath = imagePath;
+
+      // 新しい画像が指定されている場合のみアップロード
+      // if (imageFile) {
+      //   const formData = new FormData();
+      //   formData.append('image', imageFile);
+
+      //   const res = await fetch('/api/upload', {
+      //     method: 'POST',
+      //     body: formData,
+      //   });
+
+      //   const result = await res.json();
+
+      //   if (!res.ok) {
+      //     throw new Error(result.error || '画像のアップロードに失敗しました');
+      //   }
+
+      //   uploadedImagePath = result.image_path;
+      // }
+
+      // 記事の更新（JSON形式）
+      const res = await fetch(`/api/articles/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title,
+          content,
+          category_id: categoryId,
+          // image_path: uploadedImagePath, // 画像を変更してなければ元のをそのまま使う
+          image_path: null, // 更新確認のため一旦nullを設定
+        }),
+      });
+
+      console.log({
+        title,
+        content,
+        category_id: categoryId,
+        // image_path: uploadedImagePath,
+        image_path: null,
+      });
+
+      const result = await res.json();
+      console.log(result);
+      if (!res.ok) {
+        throw new Error(result.error || '記事の更新に失敗しました');
+      }
+
+      alert('記事が更新されました！');
+    } catch (err) {
+      console.error('Blog update error:', err);
+      alert('記事更新時にエラーが発生しました');
+    }
   };
 
   return (
-    <section className="max-w-3xl mx-auto space-y-6 p-4">
+    <section className="mx-auto max-w-3xl space-y-6 p-4">
       {/* タイトル入力 */}
       <Input
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="Title |"
-        className="text-3xl font-bold placeholder:text-muted"
+        className="placeholder:text-muted text-3xl font-bold"
       />
 
       {/* 画像アップロード - Arrowを使用 */}
       <Arrow
-        previewSrc={previewSrc}
+        previewSrc={imagePath}
         onDropFile={(file) => {
           const reader = new FileReader();
           reader.onloadend = () => {
-            setPreviewSrc(reader.result as string);
+            setImagePath(reader.result as string); // プレビュー用
+            setImageFile(file); // アップロード用
           };
           reader.readAsDataURL(file);
         }}
-        onRemove={() => setPreviewSrc(null)}
+        onRemove={() => {
+          setImagePath(null);
+          setImageFile(null);
+        }}
       />
 
       {/* 本文 + カテゴリ */}
       <div className="relative">
-        <div className="rounded-xl bg-[var(--color-card)] text-[var(--color-foreground)] border border-[var(--color-muted)] p-4">
+        <div className="rounded-xl border border-[var(--color-muted)] bg-[var(--color-card)] p-4 text-[var(--color-foreground)]">
           <div className="absolute top-6 right-6 z-10">
-            <CategorySelect value={category} onChange={setCategory} />
+            <CategorySelect categories={categoryList} value={categoryId} onChange={setCategoryId} />
           </div>
 
           <CustomTextarea
@@ -85,8 +176,9 @@ export default function EditBlogPage() {
       </div>
 
       {/* 更新ボタン */}
-      <div className="flex justify-end">
+      <div className="flex justify-end gap-3">
         <CreateButton onClick={handleUpdate}>Edit</CreateButton>
+        <CreateButton onClick={() => console.log('delete')}>Delete</CreateButton>
       </div>
     </section>
   );

--- a/src/components/ui/custom/CategorySelect.tsx
+++ b/src/components/ui/custom/CategorySelect.tsx
@@ -16,16 +16,13 @@ type Category = {
 
 type Props = {
   categories: Category[];
-  value: number | null;
-  onChange: (value: number) => void;
+  value: string | null;
+  onChange: (value: string) => void;
 };
 
 export const CategorySelect = ({ categories, value, onChange }: Props) => {
   return (
-    <Select
-      value={value !== null ? String(value) : ''}
-      onValueChange={(val) => onChange(Number(val))}
-    >
+    <Select value={value !== null ? String(value) : ''} onValueChange={(val) => onChange(val)}>
       <SelectTrigger className="w-[140px] text-sm">
         <SelectValue placeholder="カテゴリ選択" />
       </SelectTrigger>

--- a/src/components/ui/custom/CategorySelect.tsx
+++ b/src/components/ui/custom/CategorySelect.tsx
@@ -1,30 +1,41 @@
-//src/components/ui/custom/CategorySelect.tsx
+'use client';
 
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-  } from "@/components/ui/select";
-  
-  interface Props {
-    value: string;
-    onChange: (value: string) => void;
-  }
-  
-  export const CategorySelect = ({ value, onChange }: Props) => {
-    return (
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="w-[140px] text-sm">
-          <SelectValue placeholder="Category" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="Programming">Programming</SelectItem>
-          <SelectItem value="Design">Design</SelectItem>
-          <SelectItem value="Life">Life</SelectItem>
-        </SelectContent>
-      </Select>
-    );
-  };
-  
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// カテゴリ型
+type Category = {
+  id: number;
+  name: string;
+};
+
+type Props = {
+  categories: Category[];
+  value: number | null;
+  onChange: (value: number) => void;
+};
+
+export const CategorySelect = ({ categories, value, onChange }: Props) => {
+  return (
+    <Select
+      value={value !== null ? String(value) : ''}
+      onValueChange={(val) => onChange(Number(val))}
+    >
+      <SelectTrigger className="w-[140px] text-sm">
+        <SelectValue placeholder="カテゴリ選択" />
+      </SelectTrigger>
+      <SelectContent>
+        {categories.map((cat) => (
+          <SelectItem key={cat.id} value={String(cat.id)}>
+            {cat.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};


### PR DESCRIPTION
@kujira-challenge @fujinoyuki 
編集・削除の機能を追加しました。

対象ページ
src/app/articleedlit/[id]/page.tsx
src/components/ui/custom/CategorySelect.tsx

追加した主な機能
**・カテゴリの取得
・idに紐づく記事の取得**
**・記事の編集**
画像に変更がない場合はそのまま、画像に変更がある場合は先にstorageにアップロードしてからパスを取得して更新、という形にしています。
**・CategorySelectコンポーネント**
ハードコーディングの状態だったため、propsでカテゴリの配列が渡ってくる想定で修正しています。

記事の編集で時間がかかってしまったため、リファクタリングやカテゴリの見た目などは手付かずです。すみません。
くじらさんが調整してくださると仰ってくださったのもあるので、どうするかは相談させてください。
データローディング処理などもまだです。
ログイン中のユーザーか？みたいなところも実装が必要なのか判断つかず、まだの状態です。

あとフォルダ名がArticleEdit/[id]と大文字になっていたため、articleedit/[id]に変更しました。VSCodeで見る限りは変更できている？と思うのですが、私のgithubのWeb UI上では変わらず、変更できているかも確認お願いいたします。

Closes #59 